### PR TITLE
Feature/keyboard shortcuts overlay

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,14 +1,27 @@
 import { useLayoutStore } from './store/layoutSlice'
 import { PaneContainer } from './features/split-view/PaneContainer'
 import { LoginView } from './features/auth/LoginView'
+import { useState } from 'react'
+import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
+import { ShortcutOverlay } from './components/ShortcutOverlay'
 
 function App() {
   const { isLoggedIn } = useLayoutStore()
+  const [open, setOpen] = useState(false);
+
+  useKeyboardShortcuts(
+    () => setOpen(true),
+    () => setOpen(false),
+    isLoggedIn
+  );
 
   return (
     <div className="h-screen w-screen overflow-hidden bg-[#f1f3f6] text-kite-text-primary">
       {isLoggedIn ? (
-        <PaneContainer />
+        <>
+          <PaneContainer />
+          <ShortcutOverlay open={open} onClose={() => setOpen(false)}/>
+        </>
       ) : (
         <LoginView />
       )}

--- a/app/src/components/ShortcutOverlay.tsx
+++ b/app/src/components/ShortcutOverlay.tsx
@@ -1,0 +1,36 @@
+type Props = {
+    open: boolean,
+    onClose: () => void
+}
+
+export function ShortcutOverlay({ onClose, open }: Props) {
+    if (!open) return null
+
+    return (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+            <div
+                className="bg-white rounded-xl p-6 w-[400px] shadow-xl"
+                role="dialog"
+                aria-modal="true"
+            >
+                <h2 className="text-lg font-semibold mb-4">
+                    Keyboard Shortcuts
+                </h2>
+
+                <ul className="space-y-2 text-sm">
+                    <li><b>Ctrl + / OR ?</b> — Open help</li>
+                    <li><b>Esc</b> — Close</li>
+                    <li><b>Ctrl + S</b> — Save (placeholder)</li>
+                    <li><b>Ctrl + Z</b> — Undo (placeholder)</li>
+                </ul>
+
+                <button
+                    onClick={onClose}
+                    className="flex items-center mt-6 space-x-2 px-4 py-2 bg-kite-orange hover:bg-kite-orange-hover text-white rounded-lg transition-all shadow-sm active:scale-95 text-sm font-bold"
+                >
+                    Close
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/app/src/components/ShortcutOverlay.tsx
+++ b/app/src/components/ShortcutOverlay.tsx
@@ -18,7 +18,8 @@ export function ShortcutOverlay({ onClose, open }: Props) {
                 </h2>
 
                 <ul className="space-y-2 text-sm">
-                    <li><b>Ctrl + / OR ?</b> — Open help</li>
+                    <li><b>Ctrl + /</b> — Open help</li>
+                    <li><b>?</b> — Open help</li>
                     <li><b>Esc</b> — Close</li>
                     <li><b>Ctrl + S</b> — Save (placeholder)</li>
                     <li><b>Ctrl + Z</b> — Undo (placeholder)</li>

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+export function useKeyboardShortcuts(
+    onOpen: () => void,
+    onClose: () => void,
+    enabled: boolean = true
+) {
+    useEffect(() => {
+        if (!enabled) return
+
+        const handler = (e: KeyboardEvent) => {
+            const active = document.activeElement as HTMLElement | null
+
+            if (active?.tagName === 'INPUT') return
+            if (active?.tagName === 'TEXTAREA') return
+            if (active?.tagName === 'WEBVIEW') return
+
+            if (e.key === '?' || (e.ctrlKey && e.key === '/')) {
+                e.preventDefault()
+                onOpen()
+            }
+
+            if (e.key === 'Escape') {
+                onClose()
+            }
+        }
+
+        window.addEventListener('keydown', handler)
+        return () => window.removeEventListener('keydown', handler)
+    }, [onOpen, onClose, enabled]
+    )
+}


### PR DESCRIPTION
## Summary
Adds a lightweight keyboard shortcuts help overlay that can be triggered using '?' or Ctrl + /.

## Changes
- Added global keyboard listener using a custom hook
- Implemented shortcuts overlay modal
- Added ESC and button close behavior
- Ensured no interference with login flow or webview interactions

## Notes
- Overlay is only active after login
- No changes were made to authentication flow